### PR TITLE
De-windowsize the code, making it run and compile on Linux

### DIFF
--- a/SpacechemPatch/Program.cs
+++ b/SpacechemPatch/Program.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.IO;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using Mono.Cecil.Rocks;
 
 namespace SpacechemPatch
 {
@@ -55,22 +54,22 @@ namespace SpacechemPatch
 
         static void Main(string[] args)
         {
-            if (!File.Exists("spacechem.exe"))
+            if (!File.Exists("SpaceChem.exe"))
             {
-                Console.WriteLine("This program needs to be placed next to Spacechem.exe to work! Exiting...");
+                Console.WriteLine("This program needs to be placed next to SpaceChem.exe to work! Exiting...");
                 return;
             }
             Console.WriteLine("This program is experimental and was only tested with the Steam version of the game. There is NO WARRANTY on it. Please remember that you can always restore the original game files by verifying game integrity in Steam.");
             Console.WriteLine("Do you want to continue? [y/N]");
             if (Console.ReadKey().Key != ConsoleKey.Y) return;
             Console.WriteLine();
-            if (!File.Exists("spacechem.exe.original"))
+            if (!File.Exists("SpaceChem.exe.original"))
             {
-                Console.WriteLine("Making backup of spacechem.exe");
-                File.Copy("spacechem.exe", "spacechem.exe.original");
+                Console.WriteLine("Making backup of SpaceChem.exe");
+                File.Copy("SpaceChem.exe", "SpaceChem.exe.original");
             }
             Console.WriteLine("Patching...");
-            using (ModuleDefinition spacechemAssembly = ModuleDefinition.ReadModule("spacechem.exe"))
+            using (ModuleDefinition spacechemAssembly = ModuleDefinition.ReadModule("SpaceChem.exe"))
             using (ModuleDefinition ownAssembly = ModuleDefinition.ReadModule(System.Reflection.Assembly.GetExecutingAssembly().Location))
             {
                 Dictionary<TypeReference, TypeReference> typeReplacements;
@@ -103,10 +102,10 @@ namespace SpacechemPatch
                         patcher.ReplaceMethod(replacementMethod, targetMethod);
                     }
                 }
-                spacechemAssembly.Write("spacechem.exe.patched");
+                spacechemAssembly.Write("SpaceChem.exe.patched");
             }
-            File.Delete("spacechem.exe");
-            File.Move("spacechem.exe.patched", "spacechem.exe");
+            File.Delete("SpaceChem.exe");
+            File.Move("SpaceChem.exe.patched", "SpaceChem.exe");
             Console.WriteLine("All OK");
         }
     }

--- a/SpacechemPatch/SpacechemPatch.csproj
+++ b/SpacechemPatch/SpacechemPatch.csproj
@@ -57,10 +57,6 @@
       <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
* Remove Mono.Cecil.Rocks usage and dependency, as it's not used,
  because it isn't packaged with the default distibution
* Properly capitalize `SpaceChem.exe`, so it's correctly
  found in case sensitive filesystems

With this changes, code compiles and correctly executes on Linux.