### PR TITLE
New patch: show reactor priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ It'll then be possible to choose the patches to apply, from the list below
   during a Bond+ instruction (usually because of the maximum bonds limit of one of the atoms involved).
 * `ShowOver100kCycles`: The cycles counter in the game switches to `+INF` after 100k cycles. This patch makes it continue with `100K`,
   up until `9999K`, then `10M`. The value displayed updates at the start of the new thousand (e.g. `100999` is shown as `100K`).
-* `ShowReactorPriority`: The priority of inputs, outputs and reactors is shown in production and defense puzzles.
+* `ShowReactorPriority`: The priority of reactors, tanks and printers is shown in production and defense puzzles.
   Priority is useful for cycles optimization: in some cases, you can save one cycle by making sure that the reactor that's outputting
   a molecule has lower priority than the reactor accepting it, allowing the molecule to be accepted in the same cycle.
+  Inputs' and outputs' priority isn't shown, as they both trigger before anything else.
 
 ## Getting Started With Development
 

--- a/README.md
+++ b/README.md
@@ -11,21 +11,21 @@ It'll then be possible to choose the patches to apply, from the list below
 
 ## Available patches
 
-* `ShowBonderPriority`: The priority of a bonder is shown in the top right corner of the cell.
-  Bonder priority is something used by experienced players to predict which bonds will form when not all of the possible bonds can be formed
-  during a Bond+ instruction (usually because of the maximum bonds limit of one of the atoms involved).
-* `FixWrongOutput`: The "wrong output" bug is fixed. The game is known to sometimes accept a molecule for output even when it doesn't
-  completely match the expected molecule. The easiest way to reproduce this is to open the "Swapite" puzzle in ResearchNet 2-11-1:
-  the game will accept the input molecule without any changes. This change will apply a different molecule matching algorithm that
-  hopefully fixes these issues without introducing new ones. Please report any performance issues or unexpected results you encounter.
 * `AllowGreekInResNet` & `AllowGreekInResNetProdAndSandbox`: Gives complete support for Greek annotations/sensors in ResearchNet levels.
   In the vanilla game it's possible to get Greek annotations/sensors in ResNet productions/sandbox, by copying a reactor from EotL, so the latter
   patch is merely a QoL one. It's not possible to have Greek sensors in ResNet research assignment, though, so the former patch makes the game
   easier and it's labeled as "Cheat".
-* `ShowOver100kCycles`: The cycles counter in the game switches to `+INF` after 100k cycles. This patch makes it continue with `100K`,
-  up until `9999K`, then `10M`. The value displayed updates at the start of the new thousand (e.g. `100999` is shown as `100K`).
+* `FixWrongOutput`: The "wrong output" bug is fixed. The game is known to sometimes accept a molecule for output even when it doesn't
+  completely match the expected molecule. The easiest way to reproduce this is to open the "Swapite" puzzle in ResearchNet 2-11-1:
+  the game will accept the input molecule without any changes. This change will apply a different molecule matching algorithm that
+  hopefully fixes these issues without introducing new ones. Please report any performance issues or unexpected results you encounter.
 * `ResNetProdCustomAmount`: Allows changing the amount of outputs needed for ResNet production puzzles. The amount can be specified in
   the JSON, like for researchs. The output count used by the game is 4x the amount in the file, to keep the 10 -> 40 behaviour of the vanilla game.
+* `ShowBonderPriority`: The priority of a bonder is shown in the top right corner of the cell.
+  Bonder priority is something used by experienced players to predict which bonds will form when not all of the possible bonds can be formed
+  during a Bond+ instruction (usually because of the maximum bonds limit of one of the atoms involved).
+* `ShowOver100kCycles`: The cycles counter in the game switches to `+INF` after 100k cycles. This patch makes it continue with `100K`,
+  up until `9999K`, then `10M`. The value displayed updates at the start of the new thousand (e.g. `100999` is shown as `100K`).
 
 ## Getting Started With Development
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ It'll then be possible to choose the patches to apply, from the list below
   hopefully fixes these issues without introducing new ones. Please report any performance issues or unexpected results you encounter.
 * `ResNetProdCustomAmount`: Allows changing the amount of outputs needed for ResNet production puzzles. The amount can be specified in
   the JSON, like for researchs. The output count used by the game is 4x the amount in the file, to keep the 10 -> 40 behaviour of the vanilla game.
+* `ReverseOrderCustomResNetAssignments`: The ResearchNet custom assignments are normally sorted by ascending creation date, meaning
+  that you need to scroll the most to get to the latest puzzles. By enabling this patch, the order is reversed, so you can quickly open
+  your most recent assignments and only need to scroll for the older ones.
 * `ShowBonderPriority`: The priority of a bonder is shown in the top right corner of the cell.
   Bonder priority is something used by experienced players to predict which bonds will form when not all of the possible bonds can be formed
   during a Bond+ instruction (usually because of the maximum bonds limit of one of the atoms involved).
 * `ShowOver100kCycles`: The cycles counter in the game switches to `+INF` after 100k cycles. This patch makes it continue with `100K`,
   up until `9999K`, then `10M`. The value displayed updates at the start of the new thousand (e.g. `100999` is shown as `100K`).
+* `ShowReactorPriority`: The priority of inputs, outputs and reactors is shown in production and defense puzzles.
+  Priority is useful for cycles optimization: in some cases, you can save one cycle by making sure that the reactor that's outputting
+  a molecule has lower priority than the reactor accepting it, allowing the molecule to be accepted in the same cycle.
 
 ## Getting Started With Development
 

--- a/SpacechemPatch/Patch.cs
+++ b/SpacechemPatch/Patch.cs
@@ -13,6 +13,7 @@ namespace SpacechemPatch
         ResNetProdCustomAmount,
         ReverseOrderCustomResNetAssignments,
         ShowBonderPriority,
-        ShowOver100kCycles
+        ShowOver100kCycles,
+        ShowReactorPriority
     }
 }

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -27,20 +27,20 @@ namespace SpacechemPatch
 
         static PatchInfo()
         {
-            AddDef(Patch.ShowBonderPriority, PatchType.Enhancement, "Adds the priority number next to the bonder");
-            AddDef(Patch.FixWrongOutput, PatchType.Bugfix, "Fixes the \"Wrong Output\" bug");
-            AddDef(Patch.AllowGreekInResNetProdAndSandbox, PatchType.Enhancement,
-                   "Adds full support for Greek sensors/annotations in ResearchNet production and sandbox assignments",
-                   Patch.AllowGreekInResNet);
             AddDef(Patch.AllowGreekInResNet, PatchType.Cheat,
                    "Adds full support for Greek sensors/annotations in all ResearchNet assignments",
                    Patch.AllowGreekInResNetProdAndSandbox);
-            AddDef(Patch.ShowOver100kCycles, PatchType.Enhancement,
-                   "Shows the cycles number even if it's over 100k, by shortening it");
+            AddDef(Patch.AllowGreekInResNetProdAndSandbox, PatchType.Enhancement,
+                   "Adds full support for Greek sensors/annotations in ResearchNet production and sandbox assignments",
+                   Patch.AllowGreekInResNet);
+            AddDef(Patch.FixWrongOutput, PatchType.Bugfix, "Fixes the \"Wrong Output\" bug");
             AddDef(Patch.ResNetProdCustomAmount, PatchType.Cheat,
                    "Allows ResNet production puzzles output count to be specified in the input JSON. Count is 4x JSON count");
             AddDef(Patch.ReverseOrderCustomResNetAssignments, PatchType.Enhancement,
                    "Reverses the display order of custom ResearchNet puzzles so the most recent is listed first.");
+            AddDef(Patch.ShowBonderPriority, PatchType.Enhancement, "Adds the priority number next to the bonder");
+            AddDef(Patch.ShowOver100kCycles, PatchType.Enhancement,
+                   "Shows the cycles number even if it's over 100k, by shortening it");
             AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
                 "Shows the priority of inputs, outputs and reactors in the tooltip.");
         }

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -42,7 +42,7 @@ namespace SpacechemPatch
             AddDef(Patch.ShowOver100kCycles, PatchType.Enhancement,
                    "Shows the cycles number even if it's over 100k, by shortening it");
             AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
-                "Shows the priority of inputs, outputs and reactors in the tooltip.");
+                "Shows the priority of reactors, tanks and printers in the tooltip.");
         }
 
         private PatchInfo(PatchType type, string description, Patch[] conflictingPatches)

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -41,6 +41,8 @@ namespace SpacechemPatch
                    "Allows ResNet production puzzles output count to be specified in the input JSON. Count is 4x JSON count");
             AddDef(Patch.ReverseOrderCustomResNetAssignments, PatchType.Enhancement,
                    "Reverses the display order of custom ResearchNet puzzles so the most recent is listed first.");
+            AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
+                "Shows the priority of inputs, outputs and reactors in the tooltip.");
         }
 
         private PatchInfo(PatchType type, string description, Patch[] conflictingPatches)

--- a/SpacechemPatch/Patches/AbstractDraggable.cs
+++ b/SpacechemPatch/Patches/AbstractDraggable.cs
@@ -17,7 +17,7 @@ namespace SpacechemPatch.Patches
         [Decoy("#=q8SkGy0Us0c0Tm2sfolvmMw==")]
         public PipeList<OutputPipe> outputPipes;
         [Injected]
-        private int priority;
+        internal int priority;
 
         [Decoy("#=q_rKTlntlJmkIAnzj3v8jwWocRPnTP6SCM$DxwK7qjyw=")]
         public virtual void MakeTooltip()
@@ -25,42 +25,9 @@ namespace SpacechemPatch.Patches
 
         }
 
-        [Replaced("#=qtrBzOdYZZ65GB65VDAbBsQ==", Patch.ShowReactorPriority, KeepOriginal = true, NewNameForOriginal = "OriginalRender")]
+        [Decoy("#=qtrBzOdYZZ65GB65VDAbBsQ==")]
         public virtual void Render(SpriteBatch spriteBatch, Color color, Vector2i position)
         {
-            if (inputPipes.Count > 0 || outputPipes.Count > 0)
-            {
-                int newPriority = 1;
-                bool found = false;
-                foreach (KeyValuePair<AbstractDraggable, Vector2i> pair in ownerContainer)
-                {
-                    AbstractDraggable draggable = pair.Key;
-                    if (draggable == this)
-                    {
-                        found = true;
-                        break;
-                    }
-                    else if (draggable.inputPipes.Count > 0 || draggable.outputPipes.Count > 0)
-                    {
-                        newPriority++;
-                    }
-                }
-                if (found && newPriority != priority)
-                {
-                    // Building a tooltip is expensive, so only rebuild it if the priority changes.
-                    priority = newPriority;
-                    string nameBackup = name;
-                    name = String.Format("{0} ({1})", name, newPriority);
-                    MakeTooltip();
-                    name = nameBackup;
-                }
-            }
-            OriginalRender(spriteBatch, color, position);
-        }
-
-        public virtual void OriginalRender(SpriteBatch spriteBatch, Color color, Vector2i position)
-        {
-
         }
     }
 }

--- a/SpacechemPatch/Patches/AbstractDraggable.cs
+++ b/SpacechemPatch/Patches/AbstractDraggable.cs
@@ -8,5 +8,59 @@ namespace SpacechemPatch.Patches
     [Decoy("#=qeMkxR7vaaTlQEKn3e3$h8aYHI9cwaFN$5ZslOd5Rsf0=")]
     abstract class AbstractDraggable
     {
+        [Decoy("#=qwU8KHRzlGPCy0f_JazUY6g==")]
+        public string name;
+        [Decoy("#=q2EFFSSATZEqIYslIzTR92Q==")]
+        protected DraggableContainer ownerContainer;
+        [Decoy("#=qNsKHf_LaRXE21IlmwRCRKg==")]
+        public PipeList<InputPipe> inputPipes;
+        [Decoy("#=q8SkGy0Us0c0Tm2sfolvmMw==")]
+        public PipeList<OutputPipe> outputPipes;
+        [Injected]
+        private int priority;
+
+        [Decoy("#=q_rKTlntlJmkIAnzj3v8jwWocRPnTP6SCM$DxwK7qjyw=")]
+        public virtual void MakeTooltip()
+        {
+
+        }
+
+        [Replaced("#=qtrBzOdYZZ65GB65VDAbBsQ==", Patch.ShowReactorPriority, KeepOriginal = true, NewNameForOriginal = "OriginalRender")]
+        public virtual void Render(SpriteBatch spriteBatch, Color color, Vector2i position)
+        {
+            if (inputPipes.Count > 0 || outputPipes.Count > 0)
+            {
+                int newPriority = 1;
+                bool found = false;
+                foreach (KeyValuePair<AbstractDraggable, Vector2i> pair in ownerContainer)
+                {
+                    AbstractDraggable draggable = pair.Key;
+                    if (draggable == this)
+                    {
+                        found = true;
+                        break;
+                    }
+                    else if (draggable.inputPipes.Count > 0 || draggable.outputPipes.Count > 0)
+                    {
+                        newPriority++;
+                    }
+                }
+                if (found && newPriority != priority)
+                {
+                    // Building a tooltip is expensive, so only rebuild it if the priority changes.
+                    priority = newPriority;
+                    string nameBackup = name;
+                    name = String.Format("{0} ({1})", name, newPriority);
+                    MakeTooltip();
+                    name = nameBackup;
+                }
+            }
+            OriginalRender(spriteBatch, color, position);
+        }
+
+        public virtual void OriginalRender(SpriteBatch spriteBatch, Color color, Vector2i position)
+        {
+
+        }
     }
 }

--- a/SpacechemPatch/Patches/AbstractDraggablePrinter.cs
+++ b/SpacechemPatch/Patches/AbstractDraggablePrinter.cs
@@ -1,0 +1,7 @@
+﻿namespace SpacechemPatch.Patches
+{
+    [Decoy("#=qxOJ4hgjbkRx1TIZI8cOzbkxl0yz2EKs4Qmz5WkBpIBCa$BsDTvPpqFnnlj_PAnmj")]
+    internal class AbstractDraggablePrinter : AbstractDraggable
+    {
+    }
+}

--- a/SpacechemPatch/Patches/AbstractPipe.cs
+++ b/SpacechemPatch/Patches/AbstractPipe.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpacechemPatch.Patches
+{
+    [Decoy("#=qqXKuKU1RxgYLDGnDY7JaVulu0V9H2cGFUuXw3VPcp4g=")]
+    abstract class AbstractPipe
+    {
+    }
+}

--- a/SpacechemPatch/Patches/AbstractReactorType.cs
+++ b/SpacechemPatch/Patches/AbstractReactorType.cs
@@ -1,0 +1,7 @@
+﻿namespace SpacechemPatch.Patches
+{
+    [Decoy("#=q4qD7FM61ItTja0EPTlrb63r6ga_yHM4Ir5SdhMxQEOkU4BIqEwKdXzYSxQO26vnW")]
+    internal class AbstractReactorType : AbstractDraggable
+    {
+    }
+}

--- a/SpacechemPatch/Patches/DraggableContainer.cs
+++ b/SpacechemPatch/Patches/DraggableContainer.cs
@@ -9,10 +9,38 @@ namespace SpacechemPatch.Patches
     [Decoy("#=qXybtTWc6YL3Bmjhy$yqnlfUddKSeC7LYrXOWWRjn3Mw=")]
     class DraggableContainer : IEnumerable, IEnumerable<KeyValuePair<AbstractDraggable, Vector2i>>
     {
+        [Decoy("#=qDQbKsgZeTgbZH6Pf_xOGPA==")]
+        protected Dictionary<AbstractDraggable, Vector2i> draggableToPositionMapping = new Dictionary<AbstractDraggable, Vector2i>();
+
         [Decoy("#=qllJBIbK0DPLdvHTYBwLeTg==")]
         public void PutDraggableAtCoords(int x, int y, AbstractDraggable draggable)
         {
         }
+
+        [Replaced("#=qQsBO26A2HaS0lBEN6y0MSA==", Patch.ShowReactorPriority, KeepOriginal = true, NewNameForOriginal = "OriginalRenderProduction")]
+        public void RenderProduction(SpriteBatch spriteBatch)
+        {
+            int newPriority = 0;
+            foreach (AbstractDraggable draggable in draggableToPositionMapping.Keys)
+            {
+                if (draggable is AbstractReactorType || draggable is AbstractDraggablePrinter || draggable is DraggableStorageTank)
+                {
+                    newPriority++;
+                    if (newPriority != draggable.priority)
+                    {
+                        // Building a tooltip is expensive, so only rebuild it if the priority changes.
+                        draggable.priority = newPriority;
+                        string nameBackup = draggable.name;
+                        draggable.name = String.Format("{0} ({1})", nameBackup, newPriority);
+                        draggable.MakeTooltip();
+                        draggable.name = nameBackup;
+                    }
+                }
+            }
+            this.OriginalRenderProduction(spriteBatch);
+        }
+
+        public void OriginalRenderProduction(SpriteBatch spriteBatch) { }
 
         [Decoy("GetEnumerator")]
         public IEnumerator<KeyValuePair<AbstractDraggable, Vector2i>> GetEnumerator()

--- a/SpacechemPatch/Patches/DraggableContainer.cs
+++ b/SpacechemPatch/Patches/DraggableContainer.cs
@@ -10,7 +10,7 @@ namespace SpacechemPatch.Patches
     class DraggableContainer : IEnumerable, IEnumerable<KeyValuePair<AbstractDraggable, Vector2i>>
     {
         [Decoy("#=qDQbKsgZeTgbZH6Pf_xOGPA==")]
-        protected Dictionary<AbstractDraggable, Vector2i> draggableToPositionMapping = new Dictionary<AbstractDraggable, Vector2i>();
+        protected Dictionary<AbstractDraggable, Vector2i> draggableToPositionMapping;
 
         [Decoy("#=qllJBIbK0DPLdvHTYBwLeTg==")]
         public void PutDraggableAtCoords(int x, int y, AbstractDraggable draggable)

--- a/SpacechemPatch/Patches/DraggableStorageTank.cs
+++ b/SpacechemPatch/Patches/DraggableStorageTank.cs
@@ -1,0 +1,7 @@
+﻿namespace SpacechemPatch.Patches
+{
+    [Decoy("#=q$P5tYAWnrIOJdBAjknm6cTIPIy5tsham_DhcWP$JofHYmutDanfqA9Gk62rXBibk")]
+    internal class DraggableStorageTank : AbstractDraggable
+    {
+    }
+}

--- a/SpacechemPatch/Patches/InputPipe.cs
+++ b/SpacechemPatch/Patches/InputPipe.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpacechemPatch.Patches
+{
+    [Decoy("#=q3ooxeKiVnyB5Z_owGRwWQf7X29IOTVMF9I5KYpO_0y6wZPXkvkzadLXQ03Lj4zXx")]
+    sealed class InputPipe : AbstractPipe
+    {
+    }
+}

--- a/SpacechemPatch/Patches/OutputPipe.cs
+++ b/SpacechemPatch/Patches/OutputPipe.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpacechemPatch.Patches
+{
+    [Decoy("#=q5qZ3hMgYMXSHEEOkEEprWQB6ikqnD02yc58E1wVmhvJ2Cy89MmNn4un1kQsULNG0")]
+    sealed class OutputPipe : AbstractPipe
+    {
+    }
+}

--- a/SpacechemPatch/Patches/PipeList.cs
+++ b/SpacechemPatch/Patches/PipeList.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpacechemPatch.Patches
+{
+    [Decoy("#=qd$NHgyE25bphJ9$pmpAnjfF11zg$usxAgkO4r2nIeqTi0z_m2POTj$ZG8xGRngjk")]
+    sealed class PipeList<T> : SortedList<int, T> where T : AbstractPipe
+    {
+    }
+}

--- a/SpacechemPatch/Program.cs
+++ b/SpacechemPatch/Program.cs
@@ -417,7 +417,7 @@ namespace SpacechemPatch
                     CBCell.ReadOnly = false;
                     foreach (DataGridViewCell cell in row.Cells)
                     {
-                        cell.Style.ForeColor = default;
+                        cell.Style.ForeColor = default(Color);
                     }
                 }
             }

--- a/SpacechemPatch/SpacechemPatch.csproj
+++ b/SpacechemPatch/SpacechemPatch.csproj
@@ -78,12 +78,15 @@
     <Compile Include="Patch.cs" />
     <Compile Include="Patcher.cs" />
     <Compile Include="Patches\AbstractDraggable.cs" />
+    <Compile Include="Patches\AbstractDraggablePrinter.cs" />
     <Compile Include="Patches\AbstractFeature.cs" />
     <Compile Include="Patches\AbstractInput.cs" />
     <Compile Include="Patches\AbstractPipe.cs" />
     <Compile Include="Patches\AbstractPuzzle.cs" />
+    <Compile Include="Patches\AbstractReactorType.cs" />
     <Compile Include="Patches\AbstractUiElement.cs" />
     <Compile Include="Patches\CustomResNetPuzzleButton.cs" />
+    <Compile Include="Patches\DraggableStorageTank.cs" />
     <Compile Include="Patches\InputPipe.cs" />
     <Compile Include="Patches\MinusOnlyBonderFeature.cs" />
     <Compile Include="Patches\OutputPipe.cs" />

--- a/SpacechemPatch/SpacechemPatch.csproj
+++ b/SpacechemPatch/SpacechemPatch.csproj
@@ -80,10 +80,14 @@
     <Compile Include="Patches\AbstractDraggable.cs" />
     <Compile Include="Patches\AbstractFeature.cs" />
     <Compile Include="Patches\AbstractInput.cs" />
+    <Compile Include="Patches\AbstractPipe.cs" />
     <Compile Include="Patches\AbstractPuzzle.cs" />
     <Compile Include="Patches\AbstractUiElement.cs" />
     <Compile Include="Patches\CustomResNetPuzzleButton.cs" />
+    <Compile Include="Patches\InputPipe.cs" />
     <Compile Include="Patches\MinusOnlyBonderFeature.cs" />
+    <Compile Include="Patches\OutputPipe.cs" />
+    <Compile Include="Patches\PipeList.cs" />
     <Compile Include="Patches\PlusOnlyBonderFeature.cs" />
     <Compile Include="Patches\ReactorMember.cs" />
     <Compile Include="Patches\AbstractRenderable.cs" />


### PR DESCRIPTION
I'd like to get an extra set of eyes on this patch before merging into master. It seems to do what it's supposed to, but since I'm not very familiar with the cases where you want to know the priority of a reactor, I'd like a more experienced player to try it out.

Also, now it's showing the priority of anything that can take or output molecules because I assume you might care about the priorities of the fixed elements. Let me know if it should be limited to reactors only.