### PR TITLE
Fixing collision bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ It'll then be possible to choose the patches to apply, from the list below
   Priority is useful for cycles optimization: in some cases, you can save one cycle by making sure that the reactor that's outputting
   a molecule has lower priority than the reactor accepting it, allowing the molecule to be accepted in the same cycle.
   Inputs' and outputs' priority isn't shown, as they both trigger before anything else.
+* `StricterCollisionChecks`: Adds new collision checks and changes the timing of some existing ones to fix collision-related issues,
+  including particle smashing. It does not fix missed collisions mid-rotation: fixing those would require more frequent collision checks,
+  which is a lot harder to do. It's also stricter than the Reddit leaderboard rules, which allow Input+Fuse and Split+Out in certain
+  cases: this patch will always report a collision caused by the red waldo even if the blue waldo would have resolved it afterwards.
 * `SuperFastForward`: Allows you to run the simulation at maximum speed by holding down Ctrl and clicking on the fastest speed button
   in the bottom left corner. (The game can handle 32,767 cycles per second without pervasive changes to the engine. If your computer
   can't handle a level at this speed, it will just go as fast as it can.) Expect heavy lagging when triggering this speed.

--- a/SpacechemPatch/Equivalences.cs
+++ b/SpacechemPatch/Equivalences.cs
@@ -11745,7 +11745,11 @@ namespace SpacechemPatch
             ["#=qemlibnROmcyhIxcbT6K1ryf3zk0HbkC8fGl_FK$lJyA="] = new TypeMapping()
             {
                 typeName = "#=q0cebqUOFU_WefUEJ6ouUB07cpSgPqaqDf9oywNsfEBg="
-            }
+            },
+            ["#=qdkrhYwTvlVKUT3KMWoVTm1CHNWhszSBqjJOltUAwOa9DOilLN68Nd$S3dSdgSV2w"] = new TypeMapping()
+            {
+                typeName = "#=qnGNr7QZJtW35UqiUaaD_0gL85k2FPrN8mrwD681DJoS2HqFE$MG4yBHgJSe5cr46"
+            },
 
             // Unmatched top-level non-enum types: #=q6nFQ7j0czfMML633KX3NXw==, #=qBqzSCxNWjNPtABUjoHPdXdmmMLWNmfIdJZwq3qjbt$8=, #=qBW3QpGFIuxV5sSCs5OT5dbAwAeGDje_UNAdyp8bmiII=, #=qG4fRLTF7VgPjIT82MmidAKaNZJLG$uA83rXzQGp40b0=, #=qnH6iBO6MQt97JINRbHwrsw==, #=qqC60YH9eL7nVxVeHV2L4D707tbZfxtYtT3Yl9jgfZj_W39CBigyUDQPzPEj4I01c, #=qy0XryZJ1YjnJepAdJT57$Q==
 

--- a/SpacechemPatch/Patch.cs
+++ b/SpacechemPatch/Patch.cs
@@ -18,6 +18,7 @@ namespace SpacechemPatch
         ShowBonderPriority,
         ShowOver100kCycles,
         ShowReactorPriority,
+        StricterCollisionChecks,
         SuperFastForward
     }
 }

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -51,7 +51,7 @@ namespace SpacechemPatch
             AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
                 "Shows the priority of reactors, tanks and printers in the tooltip.");
             AddDef(Patch.StricterCollisionChecks, PatchType.Bugfix,
-                "Introduces more collision checks to the simulation, fixing most collision bugs.");
+                "Fix most collision bugs by introducing some new collision checks and changing the timing of some others.");
             AddDef(Patch.SuperFastForward, PatchType.Enhancement,
                    "Runs the simulation at maximum speed if you click on the fastest speed button while holding down Ctrl");
         }

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -50,6 +50,8 @@ namespace SpacechemPatch
                    "Shows the cycles number even if it's over 100k, by shortening it");
             AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
                 "Shows the priority of reactors, tanks and printers in the tooltip.");
+            AddDef(Patch.StricterCollisionChecks, PatchType.Bugfix,
+                "Forces a collision check after instructions that create or teleport atoms, fixing most collision bugs");
             AddDef(Patch.SuperFastForward, PatchType.Enhancement,
                    "Runs the simulation at maximum speed if you click on the fastest speed button while holding down Ctrl");
         }

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -51,7 +51,7 @@ namespace SpacechemPatch
             AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
                 "Shows the priority of reactors, tanks and printers in the tooltip.");
             AddDef(Patch.StricterCollisionChecks, PatchType.Bugfix,
-                "Forces a collision check after instructions that can introduce atoms into the reactor, fixing most collision bugs.");
+                "Introduces more collision checks to the simulation, fixing most collision bugs.");
             AddDef(Patch.SuperFastForward, PatchType.Enhancement,
                    "Runs the simulation at maximum speed if you click on the fastest speed button while holding down Ctrl");
         }

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -51,7 +51,7 @@ namespace SpacechemPatch
             AddDef(Patch.ShowReactorPriority, PatchType.Enhancement,
                 "Shows the priority of reactors, tanks and printers in the tooltip.");
             AddDef(Patch.StricterCollisionChecks, PatchType.Bugfix,
-                "Forces a collision check after instructions that create or teleport atoms, fixing most collision bugs");
+                "Forces a collision check after instructions that can introduce atoms into the reactor, fixing most collision bugs.");
             AddDef(Patch.SuperFastForward, PatchType.Enhancement,
                    "Runs the simulation at maximum speed if you click on the fastest speed button while holding down Ctrl");
         }

--- a/SpacechemPatch/Patches/AbstractInstruction.cs
+++ b/SpacechemPatch/Patches/AbstractInstruction.cs
@@ -8,5 +8,16 @@ namespace SpacechemPatch.Patches
     [Decoy("#=qCh9VWZ5rtqIQM5A0tHFVLUBdparU2HUoR8nCmvBY_NM=")]
     internal abstract class AbstractInstruction : ReactorMember
     {
+        [Injected]
+        protected void ForceCollisionCheck()
+        {
+            ownerReactor.reactorScreen.simulationEngine.DoCollisionChecks();
+        }
+
+        [Decoy("#=qIURk5R1i5M$y_uNmDTNhPQ==")]
+        public virtual Direction Activate(Waldo waldo)
+        {
+            return Direction.None;
+        }
     }
 }

--- a/SpacechemPatch/Patches/AbstractInstruction.cs
+++ b/SpacechemPatch/Patches/AbstractInstruction.cs
@@ -11,7 +11,7 @@ namespace SpacechemPatch.Patches
         [Injected]
         protected void ForceCollisionCheck()
         {
-            ownerReactor.reactorScreen.simulationEngine.DoCollisionChecks();
+            ownerReactor.reactorScreen.simulationEngine.DoForcedCollisionChecks();
         }
 
         [Decoy("#=qIURk5R1i5M$y_uNmDTNhPQ==")]

--- a/SpacechemPatch/Patches/Direction.cs
+++ b/SpacechemPatch/Patches/Direction.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpacechemPatch.Patches
+{
+    [Decoy("#=qdkrhYwTvlVKUT3KMWoVTm1CHNWhszSBqjJOltUAwOa9DOilLN68Nd$S3dSdgSV2w")]
+    internal enum Direction
+    {
+        Up = -90, // -0x0000005A
+        None = -1,
+        Right = 0,
+        Down = 90, // 0x0000005A
+        Left = 180, // 0x000000B4
+    }
+
+}

--- a/SpacechemPatch/Patches/InputInstruction.cs
+++ b/SpacechemPatch/Patches/InputInstruction.cs
@@ -5,8 +5,8 @@ using System.Text;
 
 namespace SpacechemPatch.Patches
 {
-    [Decoy("#=qmRKruzdPDMsXNhEp62qMReG6mf4FO6qI_QHkxfiyNk5F01P8jqqy6oBWleFKbp0z")]
-    internal sealed class SplitInstruction : AbstractInstruction
+    [Decoy("#=qoinRHCGTiQixtVtIh0H07yWk_nNdyBrOGhz8ILY2PSRS5jaTYN1Cehgw_BItc122")]
+    internal sealed class InputInstruction : AbstractInstruction
     {
         [Replaced("#=qIURk5R1i5M$y_uNmDTNhPQ==", Patch.StricterCollisionChecks, KeepOriginal = true, NewNameForOriginal = "OriginalActivate")]
         public override Direction Activate(Waldo waldo)

--- a/SpacechemPatch/Patches/Molecule.cs
+++ b/SpacechemPatch/Patches/Molecule.cs
@@ -13,5 +13,11 @@ namespace SpacechemPatch.Patches
         {
 
         }
+
+        [Decoy("#=qiOxgsKMOsYVwecwafCU5Aw==")]
+        public void PrepareForNewCycle()
+        {
+
+        }
     }
 }

--- a/SpacechemPatch/Patches/Reactor.cs
+++ b/SpacechemPatch/Patches/Reactor.cs
@@ -47,7 +47,7 @@ namespace SpacechemPatch.Patches
             // The next line is our only change. By forcing a collision check after the
             // molecule positions are finalized but before instructions are executed,
             // we can catch rotate-based smash attempts.
-            reactorScreen.simulationEngine.DoCollisionChecks();
+            reactorScreen.simulationEngine.DoForcedCollisionChecks();
             foreach (Waldo waldo in waldos.Values)
                 waldo.Move();
         }

--- a/SpacechemPatch/Patches/Reactor.cs
+++ b/SpacechemPatch/Patches/Reactor.cs
@@ -38,5 +38,20 @@ namespace SpacechemPatch.Patches
         {
             return null;
         }
+
+        [Replaced("#=qWRMFkk4TfVLPMRWPoTWvsA==", Patch.StricterCollisionChecks)]
+        public void OnCyclePhase1()
+        {
+            foreach (Molecule molecule in moleculeList)
+                molecule.PrepareForNewCycle();
+            // The next line is our only change. By forcing a collision check after the
+            // molecule positions are finalized but before instructions are executed,
+            // we can catch rotate-based smash attempts.
+            reactorScreen.simulationEngine.DoCollisionChecks();
+            foreach (Waldo waldo in waldos.Values)
+                waldo.Move();
+        }
+
+
     }
 }

--- a/SpacechemPatch/Patches/ReactorSimulationEngine.cs
+++ b/SpacechemPatch/Patches/ReactorSimulationEngine.cs
@@ -11,7 +11,20 @@ namespace SpacechemPatch.Patches
         [Decoy(".ctor")]
         public ReactorSimulationEngine(Reactor reactor)
         {
+        }
 
+        [Replaced("#=qhuLH3W6G8OouJ4C7pmV0hA==", Patch.StricterCollisionChecks, KeepOriginal = true, NewNameForOriginal = "OriginalDoCollisionChecks")]
+        public void DoCollisionChecks()
+        {
+            // Don't bother with duplicate checks if the simulation is already paused because of an earlier collision.
+            if (SimulationGlobals.GetRunState() == RunState.Running)
+            {
+                OriginalDoCollisionChecks();
+            }
+        }
+
+        public void OriginalDoCollisionChecks()
+        {
         }
     }
 }

--- a/SpacechemPatch/Patches/ReactorSimulationEngine.cs
+++ b/SpacechemPatch/Patches/ReactorSimulationEngine.cs
@@ -8,14 +8,32 @@ namespace SpacechemPatch.Patches
     [Decoy("#=q8Is8RtfrAzqsMWBLpfh4XewZnZ285kIdE5Zote6JdoCJJ6fdL8gXhqVPW9IX7qNH")]
     internal sealed class ReactorSimulationEngine
     {
+        // This is a hack to allow skipping the first "normal" collision check while still being able to
+        // do forced checks at the beginning of the cycle.
+        [Injected]
+        private bool forced;
+
         [Decoy(".ctor")]
         public ReactorSimulationEngine(Reactor reactor)
         {
         }
 
+        [Injected]
+        public void DoForcedCollisionChecks()
+        {
+            forced = true;
+            DoCollisionChecks();
+            forced = false;
+        }
+
         [Replaced("#=qhuLH3W6G8OouJ4C7pmV0hA==", Patch.StricterCollisionChecks, KeepOriginal = true, NewNameForOriginal = "OriginalDoCollisionChecks")]
         public void DoCollisionChecks()
         {
+            // We want to bypass the first "normal" check because we're forcing new ones that replace it.
+            if (SimulationGlobals.partialCycle == 0 && !forced)
+            {
+                return;
+            }
             // Don't bother with duplicate checks if the simulation is already paused because of an earlier collision.
             if (SimulationGlobals.GetRunState() == RunState.Running)
             {

--- a/SpacechemPatch/Patches/SimulationGlobals.cs
+++ b/SpacechemPatch/Patches/SimulationGlobals.cs
@@ -15,7 +15,11 @@ namespace SpacechemPatch.Patches
         public static void SetSimulatorSpeed(SimulatorSpeed newSpeed)
         {
         }
-
+        [Decoy("#=q$Ny1aQDzjuVBPAZI$vtgEw==")]
+        public static RunState GetRunState()
+        {
+            return RunState.Stopped;
+        }
         [Decoy("#=qQ3mOqdihhsB6qb23lBtIbw==")]
         public static void SetRunState(RunState newRunState)
         {

--- a/SpacechemPatch/Patches/SwapInstruction.cs
+++ b/SpacechemPatch/Patches/SwapInstruction.cs
@@ -8,5 +8,17 @@ namespace SpacechemPatch.Patches
     [Decoy("#=q6LuOO0mn6Dnnb0uSbunfd8q6uwX_zr1$Snj15$thTU3oIwB82JWzCIfvGh5gxIEf")]
     internal sealed class SwapInstruction : AbstractInstruction
     {
+        [Replaced("#=qIURk5R1i5M$y_uNmDTNhPQ==", Patch.StricterCollisionChecks, KeepOriginal = true, NewNameForOriginal = "OriginalActivate")]
+        public override Direction Activate(Waldo waldo)
+        {
+            Direction result = OriginalActivate(waldo);
+            ForceCollisionCheck();
+            return result;
+        }
+
+        public Direction OriginalActivate(Waldo waldo)
+        {
+            return Direction.None;
+        }
     }
 }

--- a/SpacechemPatch/Patches/SwapInstruction.cs
+++ b/SpacechemPatch/Patches/SwapInstruction.cs
@@ -8,17 +8,5 @@ namespace SpacechemPatch.Patches
     [Decoy("#=q6LuOO0mn6Dnnb0uSbunfd8q6uwX_zr1$Snj15$thTU3oIwB82JWzCIfvGh5gxIEf")]
     internal sealed class SwapInstruction : AbstractInstruction
     {
-        [Replaced("#=qIURk5R1i5M$y_uNmDTNhPQ==", Patch.StricterCollisionChecks, KeepOriginal = true, NewNameForOriginal = "OriginalActivate")]
-        public override Direction Activate(Waldo waldo)
-        {
-            Direction result = OriginalActivate(waldo);
-            ForceCollisionCheck();
-            return result;
-        }
-
-        public Direction OriginalActivate(Waldo waldo)
-        {
-            return Direction.None;
-        }
     }
 }

--- a/SpacechemPatch/Patches/Waldo.cs
+++ b/SpacechemPatch/Patches/Waldo.cs
@@ -22,5 +22,11 @@ namespace SpacechemPatch.Patches
         {
 
         }
+
+        [Decoy("#=qR3WuvRHzZw1vww9iqq$mQw==")]
+        public void Move()
+        {
+
+        }
     }
 }

--- a/SpacechemPatch/SpacechemPatch.csproj
+++ b/SpacechemPatch/SpacechemPatch.csproj
@@ -99,11 +99,13 @@
     <Compile Include="Patches\CoordsLayer.cs" />
     <Compile Include="Patches\CustomResNetPuzzleButton.cs" />
     <Compile Include="Patches\DefensePuzzle.cs" />
+    <Compile Include="Patches\Direction.cs" />
     <Compile Include="Patches\DraggableStorageTank.cs" />
     <Compile Include="Patches\FeatureType.cs" />
     <Compile Include="Patches\FuseInstruction.cs" />
     <Compile Include="Patches\FuserFeature.cs" />
     <Compile Include="Patches\HorizontalAlignment.cs" />
+    <Compile Include="Patches\InputInstruction.cs" />
     <Compile Include="Patches\InputPipe.cs" />
     <Compile Include="Patches\InstructionsPanel.cs" />
     <Compile Include="Patches\JsonPropertyAttribute.cs" />


### PR DESCRIPTION
After spending some time trying to understand how the simulation works, this is my first stab at fixing most collision bugs of the game. The idea is simple: force a collision check right after any instruction that can introduce new atoms, so issues are detected even if other instructions would resolve them in the same cycle. Note that this doesn't attempt to fix rotation-related bugs, especially the rotation overlap bug.

I'd like to either have this tested by someone who has more experience with abusing bugs, or get some test cases that I can verify myself.

Also, this patch enforces rules stricter than the unofficial Reddit leaderboard rules. Temporary collisions are reported even if they would have worked with swapped colors. Checking something complex like the Reddit rules would be a lot harder, maybe not even possible. Does it make sense to merge the patch like this, or would it just cause more confusion?