### PR TITLE
Store the persisted patches to disk as strings

### DIFF
--- a/SpacechemPatch/App.config
+++ b/SpacechemPatch/App.config
@@ -8,17 +8,4 @@
     <startup> 
         
     <supportedRuntime version="v2.0.50727" sku="Client"/></startup>
-    <userSettings>
-        <SpacechemPatch.Properties.Settings>
-            <setting name="TickedCheckboxes" serializeAs="Xml">
-                <value>
-                    <ArrayOfInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                </value>
-            </setting>
-            <setting name="SCPath" serializeAs="String">
-                <value />
-            </setting>
-        </SpacechemPatch.Properties.Settings>
-    </userSettings>
 </configuration>

--- a/SpacechemPatch/Program.cs
+++ b/SpacechemPatch/Program.cs
@@ -5,6 +5,7 @@ using Mono.Cecil;
 using System.Windows.Forms;
 using System.Drawing;
 using System.Linq;
+using System.Collections.Specialized;
 
 namespace SpacechemPatch
 {
@@ -49,9 +50,13 @@ namespace SpacechemPatch
             this.dataGridViewPatches.CellValueChanged += this.dataGridViewPatches_CellValueChanged;
 
             // restore checkboxes
-            foreach (int cbox in (int[])Properties.Settings.Default["TickedCheckboxes"])
-            {
-                dataGridViewPatches.Rows[cbox].Cells[0].Value = true;
+            StringCollection selectedPatches = (StringCollection)Properties.Settings.Default["SelectedPatches"];
+            if (selectedPatches != null) {
+                foreach (DataGridViewRow row in dataGridViewPatches.Rows)
+                {
+                    string patch = ((Patch)row.Cells["ColumnName"].Value).ToString();
+                    row.Cells[0].Value = selectedPatches.Contains(patch);
+                }
             }
 
 #if DEBUG
@@ -352,8 +357,11 @@ namespace SpacechemPatch
             this.Enabled = false;
             // store settings
             Properties.Settings.Default["SCPath"] = textBoxPath.Text;
-            Properties.Settings.Default["TickedCheckboxes"] = Enumerable.Range(0, dataGridViewPatches.RowCount)
-                                                                        .Where(i => Convert.ToBoolean(dataGridViewPatches[0, i].Value)).ToArray();
+            StringCollection selectedPatches = new StringCollection();
+            selectedPatches.AddRange(Enumerable.Range(0, dataGridViewPatches.RowCount)
+                                               .Where(i => Convert.ToBoolean(dataGridViewPatches[0, i].Value))
+                                               .Select(i => ((Patch)i).ToString()).ToArray());
+            Properties.Settings.Default["SelectedPatches"] = selectedPatches;
             Properties.Settings.Default.Save();
             // game time started
             PatchExe();

--- a/SpacechemPatch/Properties/Settings.Designer.cs
+++ b/SpacechemPatch/Properties/Settings.Designer.cs
@@ -19,22 +19,6 @@
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfInt xmlns:xsi=\"http://www.w3.org" +
-            "/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />")]
-        public int[] TickedCheckboxes
-        {
-            get
-            {
-                return ((int[])(this["TickedCheckboxes"]));
-            }
-            set
-            {
-                this["TickedCheckboxes"] = value;
-            }
-        }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string SCPath
         {
@@ -45,6 +29,20 @@
             set
             {
                 this["SCPath"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection SelectedPatches
+        {
+            get
+            {
+                return ((global::System.Collections.Specialized.StringCollection)(this["SelectedPatches"]));
+            }
+            set
+            {
+                this["SelectedPatches"] = value;
             }
         }
     }

--- a/SpacechemPatch/Properties/Settings.settings
+++ b/SpacechemPatch/Properties/Settings.settings
@@ -2,11 +2,10 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="SpacechemPatch.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
-    <Setting Name="TickedCheckboxes" Type="System.Int32[]" Scope="User">
-      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /&gt;</Value>
-    </Setting>
     <Setting Name="SCPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="SelectedPatches" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
   </Settings>


### PR DESCRIPTION
Done to prevent mismatches when the application is updated.

Also remove default values from App.config, which I hope will help
mono in storing the settings, no change observed with .NET.