### PR TITLE
 Improvements of the DeclassifyDefenses patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ It'll then be possible to choose the patches to apply, from the list below
   in ResearchNet puzzles. Puzzle creators have been building unique puzzles like this for a while now, by editing the puzzle data
   manually, but with this patch, they can do it a bit more easily. As a side effect, arbitrary bonds are also allowed in
   reactor output notes, so this patch is a superset of `AllowBondsForUnknownInNotes` and you can't turn on both at the same time.
-* `DeclassifyDefenses`: Shows the normal leaderboard/histograms after defense completion instead of the "classified" banner,
-  so that it's easy to see the stats. Sadly the game has no histogram data for these levels, but the friends scores are visible.
+* `DeclassifyDefenses`: Shows the normal leaderboard/histograms on defenses, both after completion and on hover on the
+   campaign screens, so that it's easy to see the stats.
+   Sadly the game has no histogram data for these levels, but the friends scores are visible.
 * `DefaultDebondInDisassemblyReactors`: In disassembly reactors, the Bond+ instruction is always ignored because the bonders
   can only remove bonds in them. This patch replaces Bond+ with Bond- in the instruction toolbar for these reactors, so
   you don't need to manually switch them to the Bond- state.

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -68,7 +68,7 @@ namespace SpacechemPatch
             AddDef(Patch.StricterCollisionChecks, PatchType.Bugfix,
                 "Fix most collision bugs by introducing some new collision checks and changing the timing of some others.");
             AddDef(Patch.SuperFastForward, PatchType.Enhancement,
-                   "Runs the simulation at maximum speed if you click on the fastest speed button while holding down Ctrl");
+                   "Runs the simulation at maximum speed if you click on any of the speed buttons while holding down Ctrl");
         }
 
         private PatchInfo(PatchType type, string description, Patch[] conflictingPatches)

--- a/SpacechemPatch/PatchInfo.cs
+++ b/SpacechemPatch/PatchInfo.cs
@@ -39,7 +39,8 @@ namespace SpacechemPatch
             AddDef(Patch.AllowIllegalBondsInCustomPuzzles, PatchType.Cheat,
                 "Allows any bonds to be specified when editing ResearchNet puzzles, even if they exceed the bond limit.",
                 Patch.AllowBondsForUnknownInNotes);
-            AddDef(Patch.DeclassifyDefenses, PatchType.Enhancement, "Shows cycles/reactors/symbols values after defense victories");
+            AddDef(Patch.DeclassifyDefenses, PatchType.Enhancement,
+                   "Shows cycles/reactors/symbols values of defenses, both after victory and on campaign screen");
             AddDef(Patch.DefaultDebondInDisassemblyReactors, PatchType.Enhancement,
                    "Replace the Bond+ instruction with Bond- in disassembly reactor toolbars, since Bond+ is useless in them");
             AddDef(Patch.FixTelekinesis, PatchType.Bugfix, "Fixes the \"Telekinesis\" bug");

--- a/SpacechemPatch/Patches/HistogramUtils.cs
+++ b/SpacechemPatch/Patches/HistogramUtils.cs
@@ -10,12 +10,26 @@
         [Decoy("#=qNFAjCEFWJKoXWtRXIBzsA$TltxuWThl$MVqEzqMkt8U=")]
         public static readonly string symbolsUsed;
 
-        [Decoy("#=qOCZYiIko0mI05FIEcXOhbPxTWIiHT5e9RX_CZQsX24s=")]
+        [Replaced("#=qOCZYiIko0mI05FIEcXOhbPxTWIiHT5e9RX_CZQsX24s=", Patch.DeclassifyDefenses, KeepOriginal = true, NewNameForOriginal = "OriginalMakeLeaderboard")]
         public static AbstractRenderable MakeLeaderboard(Optional<MetricLeaderboard> metricLB, Optional<int> bestMetric,
-                                                         string label, bool noLevel, bool isDefense, bool inTF2) => null;
+                                                         string label, bool noLevel, bool isDefense, bool inTF2)
+        {
+            // isDefense controls if a placeholder is shown instead of the LB, so make it always false
+            return OriginalMakeLeaderboard(metricLB, bestMetric, label, noLevel, false, inTF2);
+        }
 
-        [Decoy("#=qnrFQrgVQj$TL7kg0UMYODA==")]
+        public static AbstractRenderable OriginalMakeLeaderboard(Optional<MetricLeaderboard> metricLB, Optional<int> bestMetric,
+                                                                 string label, bool noLevel, bool isDefense, bool inTF2) => null;
+
+        [Replaced("#=qnrFQrgVQj$TL7kg0UMYODA==", Patch.DeclassifyDefenses, KeepOriginal = true, NewNameForOriginal = "OriginalMakeHistogram")]
         public static AbstractRenderable MakeHistogram(Optional<string> metricHistBars, Optional<int> thisMetric, Optional<int> bestMetric,
-                                                       string lineName, string metricName, bool noLevel, bool isDefense, bool inTF2) => null;
+                                                       string lineName, string metricName, bool noLevel, bool isDefense, bool inTF2)
+        {
+            // isDefense controls if a placeholder is shown instead of the hist, so make it always false
+            return OriginalMakeHistogram(metricHistBars, thisMetric, bestMetric, lineName, metricName, noLevel, false, inTF2);
+        }
+
+        public static AbstractRenderable OriginalMakeHistogram(Optional<string> metricHistBars, Optional<int> thisMetric, Optional<int> bestMetric,
+                                                               string lineName, string metricName, bool noLevel, bool isDefense, bool inTF2) => null;
     }
 }


### PR DESCRIPTION
Now the hist/LB are visible from the campaign hover as well.

Also add a trivial description fix